### PR TITLE
Started to port to qt5 [WORK-IN-PROGRESS]

### DIFF
--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -34,7 +34,7 @@
 const int timerInterval = 20;
 
 GLWidget::GLWidget(QWidget* parent)
-	: QGLWidget(parent), mCam_xpos(-0.5f), mCam_ypos(-0.5f), mCam_zpos(-2.0f),
+	: QOpenGLWidget(parent), mCam_xpos(-0.5f), mCam_ypos(-0.5f), mCam_zpos(-2.0f),
 	showOccupation(false),
 	atlasBlocks(NULL)
 {

--- a/src/glwidget.h
+++ b/src/glwidget.h
@@ -21,13 +21,13 @@
 
 #pragma once
 
-#include <QGLWidget>
+#include <QOpenGLWidget>
 #include <QImage>
 #include "atlas.h"
 
 class MainWindow;
 
-class GLWidget : public QGLWidget
+class GLWidget : public QOpenGLWidget
 {
 	Q_OBJECT
 public:

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -33,7 +33,7 @@
        <enum>QLayout::SetDefaultConstraint</enum>
       </property>
       <item>
-       <widget class="GLWidget" name="previewWidget" native="true">
+       <widget class="OpenGLWidget" name="previewWidget" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
           <horstretch>0</horstretch>
@@ -74,7 +74,7 @@
        </size>
       </property>
       <property name="currentIndex">
-       <number>2</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="filesTab">
        <attribute name="title">
@@ -184,7 +184,7 @@
           <x>10</x>
           <y>90</y>
           <width>341</width>
-          <height>141</height>
+          <height>162</height>
          </rect>
         </property>
         <layout class="QFormLayout" name="formLayout">
@@ -301,7 +301,7 @@
           <x>80</x>
           <y>530</y>
           <width>171</width>
-          <height>43</height>
+          <height>48</height>
          </rect>
         </property>
         <layout class="QFormLayout" name="formLayout_2">
@@ -421,7 +421,7 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>GLWidget</class>
+   <class>OpenGLWidget</class>
    <extends>QWidget</extends>
    <header>glwidget.h</header>
    <container>1</container>

--- a/src/stable.h
+++ b/src/stable.h
@@ -31,7 +31,7 @@
 #include <QFileInfo>
 #include <QDir>
 #include <QDirIterator>
-#include <QGLWidget>
+#include <QOpenGLWidget>
 #include <QDialog>
 #include <QMouseEvent>
 #include <QTime>


### PR DESCRIPTION
Started to port to qt5. Not done. @jakoch this is the last errors:

```
[linuxdonald@linuxdonald-pc src]$ make 
g++ -c -pipe -O2 -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -Wall -W -D_REENTRANT -fPIC -DNOMINMAX -DQT_NO_DEBUG -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -I. -Ifreeglut/include -isystem /usr/include/qt -isystem /usr/include/qt/QtOpenGL -isystem /usr/include/qt/QtWidgets -isystem /usr/include/qt/QtGui -isystem /usr/include/qt/QtCore -I. -I. -I/usr/lib/qt/mkspecs/linux-g++ -o mainwindow.o mainwindow.cpp
mainwindow.cpp: In Elementfunktion »void MainWindow::textureSelectionChanged()«:
mainwindow.cpp:252:23: Fehler: »class QOpenGLWidget« has no member named »highlightedChanged«; did you mean »windowTitleChanged«?
    ui->previewWidget->highlightedChanged(indices);
                       ^~~~~~~~~~~~~~~~~~
mainwindow.cpp:274:21: Fehler: »class QOpenGLWidget« has no member named »highlightedChanged«; did you mean »windowTitleChanged«?
  ui->previewWidget->highlightedChanged(indices);
                     ^~~~~~~~~~~~~~~~~~
mainwindow.cpp: In Elementfunktion »void MainWindow::refreshPressed()«:
mainwindow.cpp:404:21: Fehler: »class QOpenGLWidget« has no member named »refreshed«; did you mean »redirected«?
  ui->previewWidget->refreshed(imgAtlas);
                     ^~~~~~~~~
mainwindow.cpp:405:21: Fehler: »class QOpenGLWidget« has no member named »updateOccupation«; did you mean »updateBehavior«?
  ui->previewWidget->updateOccupation(regions);
                     ^~~~~~~~~~~~~~~~
make: *** [Makefile:978: mainwindow.o] Fehler 1
```